### PR TITLE
Hygiene and privacy

### DIFF
--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -137,7 +137,7 @@ object Boilerplate {
     def instances: Seq[InstanceDef] =
       Seq(
         InstanceDef(
-          "abstract class RenderTupleInstances {",
+          "private[claimant] abstract class RenderTupleInstances {",
           tv =>
             new TemplatedBlock(tv) {
               import tv._

--- a/src/main/scala/claimant/Render.scala
+++ b/src/main/scala/claimant/Render.scala
@@ -330,6 +330,6 @@ abstract class RenderInstances extends RenderTupleInstances with LowPriorityRend
  * Render to recursively display any of its member values, even those
  * that have Render instances.
  */
-trait LowPriorityRenderInstances {
+private[claimant] trait LowPriorityRenderInstances {
   implicit def renderAnyRef[A]: Render[A] = Render.str(_.toString)
 }

--- a/src/main/scala/claimant/render/CaseClass.scala
+++ b/src/main/scala/claimant/render/CaseClass.scala
@@ -38,7 +38,7 @@ new _root_.claimant.Render[$A] {
 
   ..$evs
 
-  def renderInto(sb: StringBuilder, a: $A): StringBuilder = {
+  def renderInto(sb: _root_.scala.collection.mutable.StringBuilder, a: $A): _root_.scala.collection.mutable.StringBuilder = {
     sb.append($name)
     sb.append("(")
     ..$stmts


### PR DESCRIPTION
A couple of minor things: makes some prioritization stuff private, and fixes a macro hygiene issue (which could conceivably cause problems if someone has `java.lang.StringBuilder` imported).